### PR TITLE
ENG-1237: Support edge runtime compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 package-lock.json
 dist
 coverage
+.vscode/*

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "url": "https://github.com/stefan-prokop-cz/verify-apple-id-token/issues"
   },
   "dependencies": {
-    "jsonwebtoken": "^9.0.0",
-    "jwks-rsa": "^3.0.0"
+    "jose": "^4.14.4",
+    "jsonwebtoken": "^9.0.0"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verify-apple-id-token",
-  "version": "3.0.1",
+  "version": "3.0.1-jose",
   "description": "Verify the Apple id token on the server side.",
   "main": "./dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "url": "https://github.com/stefan-prokop-cz/verify-apple-id-token/issues"
   },
   "dependencies": {
-    "jose": "^4.14.4",
-    "jsonwebtoken": "^9.0.0"
+    "jose": "^4.14.4"
   },
   "devDependencies": {
     "@types/jest": "29.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verify-apple-id-token",
-  "version": "3.0.1-jose",
+  "version": "3.0.1",
   "description": "Verify the Apple id token on the server side.",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/lib/verifyAppleIdToken.ts
+++ b/src/lib/verifyAppleIdToken.ts
@@ -1,4 +1,4 @@
-import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
+import { createRemoteJWKSet, decodeProtectedHeader, jwtVerify } from "jose";
 import { VerifyAppleIdTokenParams } from "./types";
 
 export const APPLE_BASE_URL = "https://appleid.apple.com";
@@ -14,9 +14,10 @@ export const getApplePublicKey = async (kid: string, alg: string) => {
 };
 
 export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
-  const claims = decodeJwt(params.idToken);
+  const { alg, kid } = decodeProtectedHeader(params.idToken);
 
-  const applePublicKey = await getApplePublicKey(claims.kid as string, claims.alg as string);
+  const applePublicKey = await getApplePublicKey(kid, alg);
+
   const { payload: jwtClaims } = await jwtVerify(params.idToken, applePublicKey);
 
   if (jwtClaims?.nonce !== params.nonce) {

--- a/src/lib/verifyAppleIdToken.ts
+++ b/src/lib/verifyAppleIdToken.ts
@@ -21,7 +21,7 @@ export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
   const { payload: jwtClaims } = await jwtVerify(params.idToken, applePublicKey);
 
   if (jwtClaims?.nonce !== params.nonce) {
-    throw new Error(`The nonce parameter does not match this client - nonce: ${jwtClaims.nonce} | expected: ${params.nonce}`);
+    throw new Error(`The nonce parameter does not match - nonce: ${jwtClaims.nonce} | expected: ${params.nonce}`);
   }
 
   if (jwtClaims?.iss !== APPLE_BASE_URL) {

--- a/src/lib/verifyAppleIdToken.ts
+++ b/src/lib/verifyAppleIdToken.ts
@@ -1,5 +1,4 @@
-import { createRemoteJWKSet, jwtVerify } from "jose";
-import * as jwt from "jsonwebtoken";
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from "jose";
 import { VerifyAppleIdTokenParams } from "./types";
 
 export const APPLE_BASE_URL = "https://appleid.apple.com";
@@ -15,10 +14,9 @@ export const getApplePublicKey = async (kid: string, alg: string) => {
 };
 
 export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
-  const decoded = jwt.decode(params.idToken, { complete: true });
-  const { kid, alg } = decoded.header;
+  const claims = decodeJwt(params.idToken);
 
-  const applePublicKey = await getApplePublicKey(kid, alg);
+  const applePublicKey = await getApplePublicKey(claims.kid as string, claims.alg as string);
   const { payload: jwtClaims } = await jwtVerify(params.idToken, applePublicKey);
 
   if (jwtClaims?.nonce !== params.nonce) {

--- a/src/lib/verifyAppleIdToken.ts
+++ b/src/lib/verifyAppleIdToken.ts
@@ -8,8 +8,8 @@ export const JWKS_APPLE_URI = "/auth/keys";
 export const getApplePublicKey = async (kid: string, alg: string) => {
   const JWKS = createRemoteJWKSet(new URL(`${APPLE_BASE_URL}${JWKS_APPLE_URI}`));
   const key = await JWKS({
-    kid,
     alg,
+    kid,
   });
   return key;
 };
@@ -20,6 +20,10 @@ export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
 
   const applePublicKey = await getApplePublicKey(kid, alg);
   const { payload: jwtClaims } = await jwtVerify(params.idToken, applePublicKey);
+
+  if (jwtClaims?.nonce !== params.nonce) {
+    throw new Error(`The nonce parameter does not match this client - nonce: ${jwtClaims.nonce} | expected: ${params.nonce}`);
+  }
 
   if (jwtClaims?.iss !== APPLE_BASE_URL) {
     throw new Error(`The iss does not match the Apple URL - iss: ${jwtClaims.iss} | expected: ${APPLE_BASE_URL}`);

--- a/src/lib/verifyAppleIdToken.ts
+++ b/src/lib/verifyAppleIdToken.ts
@@ -1,45 +1,31 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
 import * as jwt from "jsonwebtoken";
-import * as jwksClient from "jwks-rsa";
-import { VerifyAppleIdTokenParams, VerifyAppleIdTokenResponse } from "./types";
+import { VerifyAppleIdTokenParams } from "./types";
 
 export const APPLE_BASE_URL = "https://appleid.apple.com";
 export const JWKS_APPLE_URI = "/auth/keys";
 
-export const getApplePublicKey = async (kid: string) => {
-  const client = jwksClient({
-    cache: true,
-    jwksUri: `${APPLE_BASE_URL}${JWKS_APPLE_URI}`,
+export const getApplePublicKey = async (kid: string, alg: string) => {
+  const JWKS = createRemoteJWKSet(new URL(`${APPLE_BASE_URL}${JWKS_APPLE_URI}`));
+  const key = await JWKS({
+    kid,
+    alg,
   });
-  const key = await new Promise<jwksClient.SigningKey>((resolve, reject) => {
-    client.getSigningKey(kid, (error, result) => {
-      if (error) {
-        return reject(error);
-      }
-      return resolve(result);
-    });
-  });
-  return key.getPublicKey();
+  return key;
 };
 
 export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
   const decoded = jwt.decode(params.idToken, { complete: true });
   const { kid, alg } = decoded.header;
 
-  const applePublicKey = await getApplePublicKey(kid);
-  const jwtClaims = jwt.verify(params.idToken, applePublicKey, {
-    algorithms: [alg as jwt.Algorithm],
-    nonce: params.nonce,
-  }) as VerifyAppleIdTokenResponse;
+  const applePublicKey = await getApplePublicKey(kid, alg);
+  const { payload: jwtClaims } = await jwtVerify(params.idToken, applePublicKey);
 
   if (jwtClaims?.iss !== APPLE_BASE_URL) {
-    throw new Error(
-      `The iss does not match the Apple URL - iss: ${jwtClaims.iss} | expected: ${APPLE_BASE_URL}`
-    );
+    throw new Error(`The iss does not match the Apple URL - iss: ${jwtClaims.iss} | expected: ${APPLE_BASE_URL}`);
   }
 
-  const isFounded = []
-    .concat(jwtClaims.aud)
-    .some((aud) => [].concat(params.clientId).includes(aud));
+  const isFounded = [].concat(jwtClaims.aud).some((aud) => [].concat(params.clientId).includes(aud));
 
   if (isFounded) {
     ["email_verified", "is_private_email"].forEach((field) => {
@@ -51,7 +37,5 @@ export const verifyToken = async (params: VerifyAppleIdTokenParams) => {
     return jwtClaims;
   }
 
-  throw new Error(
-    `The aud parameter does not include this client - is: ${jwtClaims.aud} | expected: ${params.clientId}`
-  );
+  throw new Error(`The aud parameter does not include this client - is: ${jwtClaims.aud} | expected: ${params.clientId}`);
 };

--- a/src/test/verifyAppleIdToken.test.ts
+++ b/src/test/verifyAppleIdToken.test.ts
@@ -98,7 +98,7 @@ describe("Verify Apple idToken", () => {
       );
       await verifyAppleIdToken({ idToken, clientId });
     } catch (error) {
-      return expect(error.message).toMatch(/jwt expired/);
+      return expect(error.message).toMatch(/"exp" claim timestamp check failed/);
     }
     throw new Error("Expected to throw");
   });
@@ -116,7 +116,7 @@ describe("Verify Apple idToken", () => {
       );
       await verifyAppleIdToken({ idToken, clientId, nonce: "def" });
     } catch (error) {
-      return expect(error.message).toMatch(/jwt nonce invalid/);
+      return expect(error.message).toMatch(/The nonce parameter does not match/);
     }
     throw new Error("Expected to throw");
   });


### PR DESCRIPTION
When attempting to use the current 3.0.1 `verify-apple-id-token` package in the Vercel Edge Runtime an error appears at build time related to the use of dynamic evaluation:

https://nextjs.org/docs/messages/edge-dynamic-code-evaluation 

This PR provides a solution to this issue by replacing the `jsonwebtoken` and `jwks-rsa` libraries by `jose` which provides the same functionality in a single well supported package with albeit a slightly different API.  

In this context, `jose` has the important characteristic of being compatible with various edge runtimes including Vercel's.

https://github.com/panva/jose#supported-runtimes

